### PR TITLE
Upgrade to nodejs10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 > Run commands in a docker like node environment
 
+![npm (scoped)](https://img.shields.io/npm/v/@fransvilhelm/lambi)
+![Travis (.org)](https://img.shields.io/travis/adambrgmn/lambi)
+
 ## Description
 
 `lambi` is mainly a cli util used to run commands in a

--- a/dockerfiles/npm/Dockerfile
+++ b/dockerfiles/npm/Dockerfile
@@ -2,7 +2,7 @@
 # The Docker env is used in order to mimic the AWS Lambda execution environment
 # as closely as possible
 
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 ENV PATH "${PATH}:./node_modules/.bin"
 
 # We copy package.json and yarn.lock before any other files in order to leverage

--- a/dockerfiles/yarn/Dockerfile
+++ b/dockerfiles/yarn/Dockerfile
@@ -2,7 +2,7 @@
 # The Docker env is used in order to mimic the AWS Lambda execution environment
 # as closely as possible
 
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 ENV PATH "${PATH}:./node_modules/.bin"
 
 RUN npm install -g yarn


### PR DESCRIPTION
Node JS 8 wil reach EOL this year. And Node JS 10 will be next LTS. Therefore we will from now on
use nodejs10.x as the docker image.

BREAKING CHANGE: Move from nodejs8.10 to nodejs10.x
